### PR TITLE
Update tests to expose X-foo and X-bar headers in GraphQL schema

### DIFF
--- a/tests/core/snapshots/test-upstream-headers.md_0.snap
+++ b/tests/core/snapshots/test-upstream-headers.md_0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/core/spec.rs
 expression: response
-snapshot_kind: text
 ---
 {
   "status": 200,
@@ -17,7 +16,9 @@ snapshot_kind: text
         {
           "id": 3
         }
-      ]
+      ],
+      "fooField": "bar",
+      "barField": "baz"
     }
   }
 }

--- a/tests/core/snapshots/test-upstream-headers.md_client.snap
+++ b/tests/core/snapshots/test-upstream-headers.md_client.snap
@@ -1,13 +1,14 @@
 ---
 source: tests/core/spec.rs
 expression: formatted
-snapshot_kind: text
 ---
 type Post {
   id: Int
 }
 
 type Query {
+  barField: String!
+  fooField: String!
   posts: [Post]
 }
 

--- a/tests/core/snapshots/test-upstream-headers.md_merged.snap
+++ b/tests/core/snapshots/test-upstream-headers.md_merged.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/core/spec.rs
 expression: formatter
-snapshot_kind: text
 ---
 schema @server @upstream(allowedHeaders: ["X-bar", "x-foo"]) @link(src: "schema_0.graphql", type: Config) {
   query: Query
@@ -12,5 +11,7 @@ type Post {
 }
 
 type Query {
+  barField: String! @expr(body: "{{.headers.x-bar}}")
+  fooField: String! @expr(body: "{{.headers.x-foo}}")
   posts: [Post] @http(url: "http://jsonplaceholder.typicode.com/posts")
 }

--- a/tests/execution/test-upstream-headers.md
+++ b/tests/execution/test-upstream-headers.md
@@ -11,6 +11,8 @@ schema {
 }
 type Query {
   posts: [Post] @http(url: "http://jsonplaceholder.typicode.com/posts")
+  fooField: String! @expr(body: "{{.headers.x-foo}}")
+  barField: String! @expr(body: "{{.headers.x-bar}}")
 }
 type Post {
   id: Int
@@ -44,5 +46,5 @@ type Post {
     X-foo: bar
     X-bar: baz
   body:
-    query: query { posts { id } }
+    query: query { posts { id } fooField barField }
 ```


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
